### PR TITLE
Correct Bug with Storyblok Comments

### DIFF
--- a/Block/Block.php
+++ b/Block/Block.php
@@ -115,11 +115,7 @@ class Block extends AbstractStoryblok
 
     protected function _toHtml(): string
     {
-        $editable = '';
-
-        if ($this->_request->getParam(Router::STORYBLOK_EDITOR_KEY)) {
-            $editable = $this->getData('_editable') ?? '';
-        }
+        $editable = $this->getData('_editable') ?? '';
 
         return $editable . parent::_toHtml();
     }

--- a/Controller/Router.php
+++ b/Controller/Router.php
@@ -80,7 +80,7 @@ class Router implements RouterInterface
 
         $storyRequest = null;
 
-        if ($request->getParam(self::STORYBLOK_EDITOR_KEY)) {
+        if ($request->getParam(self::STORYBLOK_EDITOR_KEY) || $this->config->isDevModeEnabled()) {
             $storyRequest = new StoryRequest(version: Version::Draft);
         }
 

--- a/Model/StoryRepository.php
+++ b/Model/StoryRepository.php
@@ -76,7 +76,7 @@ class StoryRepository implements StoryRepositoryInterface
         ?StoryRequest $request = null,
     ): Story {
         try {
-            $response = $this->storyBlockClientWrapper->getStoriesApi()->bySlug($slug);
+            $response = $this->storyBlockClientWrapper->getStoriesApi()->bySlug($slug, $request);
             $storyData = $response->story;
             $storyData[StoryInterface::KEY_CACHE_VERSION] = $response->cv;
             $story = $this->storyFactory->create();


### PR DESCRIPTION
+ Storyblok comments are only included when story is in drfat mode so don't need to check for query
+ Ensure draft version of the story is requested when either in dev mode or _storyblok query exists