### PR TITLE
Feature: Ensure Invalid Slugs Still Allow Pages to Render

### DIFF
--- a/Block/Block.php
+++ b/Block/Block.php
@@ -47,11 +47,17 @@ class Block extends AbstractStoryblok
         return $this->getData('block') ?? $this->blockFactory->create();
     }
 
-    public function renderField(string $fieldName): string
+    public function renderField(string $fieldName): ?string
     {
+        $story = $this->getStory();
+
+        if (!$story) {
+            return null;
+        }
+
         return $this->fieldRenderer->renderField(
             $this->getBlock()->getData($fieldName),
-            $this->getStory()
+            $story
         );
     }
 

--- a/Block/Story.php
+++ b/Block/Story.php
@@ -20,21 +20,28 @@ class Story extends AbstractStoryblok implements IdentityInterface
         return parent::getData($key, $index) ?? $this->getData('story')?->getData($key, $index);
     }
 
-    public function getContent(): StoryblokBlock
+    public function getContent(): ?StoryblokBlock
     {
-        return $this->getStory()->getContent();
+        return $this->getStory()?->getContent();
     }
 
     public function getContentHtml(
         array $data = [],
     ): string {
+        $story = $this->getStory();
+        $content = $this->getContent();
+
+        if (!$story || !$content) {
+            return '';
+        }
+
         $blockName = 'content-'
             . $this->getContent()->getComponent()
             . '-'
-            . md5(json_encode($this->getStory()->getData()));
+            . md5(json_encode($story->getData()));
 
-        $data['block'] = $this->getContent();
-        $data['story'] = $this->getStory();
+        $data['block'] = $content;
+        $data['story'] = $story;
 
         $block = $this->getLayout()
             ->createBlock(Block::class, $blockName)
@@ -71,8 +78,8 @@ class Story extends AbstractStoryblok implements IdentityInterface
         return $result;
     }
 
-    public function getComponent(): string
+    public function getComponent(): ?string
     {
-        return $this->getContent()->getComponent();
+        return $this->getContent()?->getComponent();
     }
 }

--- a/Block/StoryList.php
+++ b/Block/StoryList.php
@@ -39,7 +39,7 @@ class StoryList extends Story
 
         $parent = $this->getStory();
 
-        if (!$this->scopeConfig->isStoryListsEnabled() || !$parent->getIsStartpage()) {
+        if (!$parent || !$this->scopeConfig->isStoryListsEnabled() || !$parent->getIsStartpage()) {
             return null;
         }
 
@@ -84,7 +84,7 @@ class StoryList extends Story
 
     public function toHtml()
     {
-        if ($this->getStory()->getIsStartpage()) {
+        if ($this->getStory()?->getIsStartpage()) {
             return parent::toHtml();
         }
 


### PR DESCRIPTION
# Description

Page rendering was breaking if the story slug provided references non-existing story, this fix ensures pages will render even with invalid slugs.

Adds null safety for missing Storyblok slugs
Handle cases where Storyblok slugs don't exist by:

- Catching exceptions in getStory() and returning null 
- Adding null checks to all methods that depend on story data
- Using null-safe operators and early returns
