### PR TITLE
BUGFIX: allow null to be passed to ViewModel

### DIFF
--- a/ViewModel/SeoMetaData.php
+++ b/ViewModel/SeoMetaData.php
@@ -27,12 +27,12 @@ class SeoMetaData implements ArgumentInterface
     /**
      * Prepares and returns a filtered list of meta tags for HTML output.
      *
-     * @param array $storyblokMetatags The raw metaData array from Storyblok content.
+     * @param array|null $storyblokMetatags The raw metaData array from Storyblok content.
      *
      * @return array Associative array of ['meta_name' => 'meta_value'] suitable for direct output.
      */
     public function getPreparedMetatags(
-        array $storyblokMetatags
+        ?array $storyblokMetatags = []
     ): array {
         if (empty($storyblokMetatags)) {
             return [];


### PR DESCRIPTION
- BUGFIX: Allow Null to be passed to \WindAndKite\Storyblok\ViewModel\SeoMetaData::getPreparedMetatags