### PR TITLE
Bugfix Handle Metadata as string

### DIFF
--- a/ViewModel/SeoMetaData.php
+++ b/ViewModel/SeoMetaData.php
@@ -27,13 +27,17 @@ class SeoMetaData implements ArgumentInterface
     /**
      * Prepares and returns a filtered list of meta tags for HTML output.
      *
-     * @param array|null $storyblokMetatags The raw metaData array from Storyblok content.
+     * @param array|string|null $storyblokMetatags The raw metaData array from Storyblok content.
      *
      * @return array Associative array of ['meta_name' => 'meta_value'] suitable for direct output.
      */
     public function getPreparedMetatags(
-        ?array $storyblokMetatags = []
+        $storyblokMetatags = []
     ): array {
+        if (is_string($storyblokMetatags)) {
+            $storyblokMetatags = json_decode($storyblokMetatags, true);
+        }
+
         if (empty($storyblokMetatags)) {
             return [];
         }


### PR DESCRIPTION
Bugfix: When metadata plugin is present but never completed, Storyblok passes key as empty string