### PR TITLE
Bug Fix - Resolve undefined constant error

### DIFF
--- a/Service/SearchCriteriaConverter.php
+++ b/Service/SearchCriteriaConverter.php
@@ -133,6 +133,7 @@ class SearchCriteriaConverter
 
     public function __construct(
         private \WindAndKite\Storyblok\Scope\Config $scopeConfig,
+        private StoryblokSessionManager $storyblokSessionManager,
         private RequestInterface $request,
     ) {}
 
@@ -163,15 +164,8 @@ class SearchCriteriaConverter
             }
         }
 
-        $version = $searchCriteria->getVersion();
+        $version = $data['version'] ?? $this->storyblokSessionManager->getStoryblokApiVersion();
 
-        if (!$version) {
-            $version = Version::Published;
-
-            if ($this->request->getParam(Router::STORYBLOK_EDITOR_KEY) || $this->scopeConfig->isDevModeEnabled()) {
-                $version = Version::Draft;
-            }
-        }
 
         $request = new StoriesRequest(
             $searchCriteria->getLanguage(),


### PR DESCRIPTION
# Description

Resolves 'undefined constant' error thrown on Storyblok pages due to SearchCriteriaConverter.php using old version checker

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ensuring no 'undefined constant' error is thrown when accessing pages with Storyblok content

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

