### PR TITLE
Feature/sb homepage

### DIFF
--- a/Plugin/Home.php
+++ b/Plugin/Home.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WindAndKite\Storyblok\Plugin;
+
+use Magento\Cms\Controller\Index\Index;
+use Magento\Framework\Controller\Result\Forward;
+use Magento\Framework\App\RequestInterface;
+use WindAndKite\Storyblok\Scope\Config;
+use WindAndKite\Storyblok\Controller\Router;
+
+class Home {
+    public function __construct(
+        protected Router $router,
+        protected RequestInterface $request,
+        protected Config $scopeConfig
+    ) {}
+
+    public function afterExecute(
+        Index $subject,
+        $result
+    ) {
+        if (!$this->scopeConfig->isHomeEnabled() || !$this->scopeConfig->getHomeSlug()) {
+            return $result;
+        }
+
+        if ($result instanceof  Forward) {
+            $request = $this->request->setPathInfo($this->scopeConfig->getHomeSlug());
+            $storyResult = $this->router->match($request);
+
+            if ($storyResult) {
+                return $storyResult;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/Scope/Config.php
+++ b/Scope/Config.php
@@ -22,6 +22,8 @@ class Config
     private const XML_PATH_SITEMAP_EXCLUDE_FOLDERS = 'storyblok/sitemap/exclude_folders';
     private const XML_PATH_ENABLE_STORY_LISTS = 'storyblok/story_lists/enable';
     private const XML_PATH_STORIES_PER_PAGE = 'storyblok/story_lists/per_page';
+    private const XML_PATH_ENABLE_HOME = 'storyblok/home/enable_home';
+    private const XML_PATH_HOME_SLUG = 'storyblok/home/home_slug';
 
     /**
      * There is and never will be an admin config field for this, to set this up please use
@@ -218,6 +220,28 @@ class Config
     ): ?string {
         return $this->scopeConfig->getValue(
             self::XML_PATH_DEV_WEBHOOK_SECRET,
+            $scopeType,
+            $scopeCode
+        );
+    }
+
+    public function isHomeEnabled(
+        string $scopeType = ScopeInterface::SCOPE_STORE,
+        null|int|string $scopeCode = null,
+    ): bool {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_ENABLE_HOME,
+            $scopeType,
+            $scopeCode,
+        );
+    }
+
+    public function getHomeSlug(
+        string $scopeType = ScopeInterface::SCOPE_STORE,
+        null|int|string $scopeCode = null,
+    ): ?string {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_HOME_SLUG,
             $scopeType,
             $scopeCode
         );

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -2,8 +2,8 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <tab id="storyblok" translate="label" sortOrder="10">
-            <label>Storyblok</label>
+        <tab id="windandkite" translate="label" sortOrder="500" class="windandkite-tab">
+            <label>Wind and Kite</label>
         </tab>
         <section id="storyblok"
                  translate="label"
@@ -13,7 +13,7 @@
                  showInStore="1">
             <class>separator-top</class>
             <label>Storyblok Integration</label>
-            <tab>storyblok</tab>
+            <tab>windandkite</tab>
             <resource>WindAndKite_Storyblok::config</resource>
             <group id="general" translate="label" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="0">
                 <label>General Settings</label>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -200,7 +200,7 @@
             </group>
             <group id="home" translate="label" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Home Page Settings</label>
-                <field id="enable_home" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="enable_home" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Switch the default Magento CMS homepage to Storyblok</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <comment>Set to "Yes" to switch the default Magento homepage to a Storyblok one.</comment>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -198,6 +198,27 @@
                     <comment>Number of stories to display per page. Leave empty to display all stories.</comment>
                 </field>
             </group>
+            <group id="home" translate="label" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Home Page Settings</label>
+                <field id="enable_home" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Switch the default Magento CMS homepage to Storyblok</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment>Set to "Yes" to switch the default Magento homepage to a Storyblok one.</comment>
+                </field>
+                <field id="home_slug"
+                       translate="label"
+                       type="text"
+                       sortOrder="10"
+                       showInDefault="1"
+                       showInWebsite="1"
+                       showInStore="1">
+                    <depends>
+                        <field id="enable_home">1</field>
+                    </depends>
+                    <label>Home Page Slug</label>
+                    <comment>Enter the Storyblok slug of the story to use as the home page (e.g., 'home').</comment>
+                </field>
+            </group>
         </section>
     </system>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -22,6 +22,10 @@
                 <enable>1</enable>
                 <per_page>25</per_page>
             </story_lists>
+            <home>
+                <enable_home>1</enable_home>
+                <home_slug>home</home_slug>
+            </home>
         </storyblok>
     </default>
 </config>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -11,4 +11,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Cms\Controller\Index\Index">
+        <plugin name="home_to_storyblok" type="WindAndKite\Storyblok\Plugin\Home" sortOrder="100"/>
+    </type>
 </config>

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -1,0 +1,7 @@
+.windandkite-tab .admin__page-nav-title strong:before {
+    content: "";
+    background-image: url("WindAndKite_Storyblok::images/windandkite-logo.svg");
+    background-size: auto 19px;
+    background-repeat: no-repeat;
+    padding-left: 30px;
+}

--- a/view/adminhtml/web/css/source/module/_menu.less
+++ b/view/adminhtml/web/css/source/module/_menu.less
@@ -1,0 +1,7 @@
+.windandkite-tab .admin__page-nav-title strong:before {
+    content: "";
+    background-image: url("WindAndKite_Storyblok::images/windandkite-logo.svg");
+    background-size: auto 20px;
+    background-repeat: no-repeat;
+    padding-left: 25px;
+}

--- a/view/adminhtml/web/images/windandkite-logo.svg
+++ b/view/adminhtml/web/images/windandkite-logo.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="147px" height="145px" viewBox="0 0 147 145" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>Group 3</title>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="_Colour-0-light-Copy" transform="translate(-696.000000, -373.000000)">
+            <g id="Group" transform="translate(340.930000, 373.000000)">
+                <g id="Group-3" transform="translate(356.070000, 0.000000)" fill="#FF0000">
+                    <polygon id="Rectangle" transform="translate(72.500000, 72.500000) rotate(-270.000000) translate(-72.500000, -72.500000) " points="1.08048832e-11 6.2783112e-13 110.903943 6.2783112e-13 145 145 -5.15143483e-13 109.99006"></polygon>
+                </g>
+                <polygon id="+" fill="#FFFFFF" fill-rule="nonzero" transform="translate(439.570000, 61.393333) rotate(-315.000000) translate(-439.570000, -61.393333) " points="448.80849 98.7866667 448.80849 70.7416667 479.07 70.7416667 479.07 52.1180339 448.80849 52.1180339 448.80849 24 430.258766 24 430.258766 52.1180339 400.07 52.1180339 400.07 70.7416667 430.258766 70.7416667 430.258766 98.7866667"></polygon>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
# Description

1. Add new configuration for homepage to be served from SB. When enabled use passed slug instead of Magento CMS page
2. Moved admin configuration into Wind & Kite tab and added logo to this.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Confirmed that the setting is enabled by default
- [x] Confirmed that when disabled the default Magento CMS homepage shows
- [x] Confirmed that setting a different homepage on one store view correctly shows the right page per store view.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings