### PR TITLE
Force Magento to use Built In Cache during SB Session

### DIFF
--- a/Plugin/ForceBuiltInCachePlugin.php
+++ b/Plugin/ForceBuiltInCachePlugin.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WindAndKite\Storyblok\Plugin;
+
+use Magento\PageCache\Model\Config;
+use WindAndKite\Storyblok\Scope\Config as StoryblokScopeConfig;
+use WindAndKite\Storyblok\Service\StoryblokSessionManager;
+
+/**
+ * Interceptor for @see Config
+ */
+class ForceBuiltInCachePlugin
+{
+    public function __construct(
+        private readonly StoryblokSessionManager $storyblokSessionManager,
+        private readonly StoryblokScopeConfig $scopeConfig,
+    ) {}
+
+    /**
+     * Intercepted method getType.
+     *
+     * Force the Page Cache type to 'Built-In' during Storyblok sessions. This prevents Magento from wrapping blocks in
+     * ESI tags (<esi:include />) when the page is loaded within the Storyblok iframe. By forcing Built-in mode, Magento
+     * renders block content inline, ensuring:
+     *  1. The browser's HTML5 parser doesn't disfigure the layout due to self-closing ESI tags.
+     *  2. Content-specific blocks (like menus and carts) are visible and editable within the Storyblok preview.
+     *
+     * @param Config $subject
+     * @param int $result
+     *
+     * @return int
+     * @see Config::getType
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function afterGetType(
+        Config $subject,
+        int $result
+    ): int {
+        if ($this->storyblokSessionManager->isValidEditorSession() || $this->scopeConfig->isDevModeEnabled()) {
+            return Config::BUILT_IN;
+        }
+
+        return $result;
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -14,4 +14,8 @@
     <type name="Magento\Cms\Controller\Index\Index">
         <plugin name="home_to_storyblok" type="WindAndKite\Storyblok\Plugin\Home" sortOrder="100"/>
     </type>
+    <type name="Magento\PageCache\Model\Config">
+        <plugin name="WindAndKite_Storyblok::force_built_in_cache"
+                type="WindAndKite\Storyblok\Plugin\ForceBuiltInCachePlugin"/>
+    </type>
 </config>


### PR DESCRIPTION
# Description

Add a plugin to force MAgento to use Built in Cache during Storyblok editing sessions or when dev mode is enabled, When Varnish is active Magento will replace blocks with a TTL with a varnish `<esi:include>` tag that in normal operation would be replaced by varnish before being sent to the user, however during a Storyblok bridge editor the iframe bypasses varnish but the `esi:include` tags  remain meaning that content isn't present or HTML is broken. this new plugin forces magento to use the standard built in cache which means that blocks won't be replaced with the ESI tags

https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/cache/use-varnish-esi

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] Enable Varnish within Dev Environment and configure Magento to use that
- [ ] Enable Full Page Cache
- [ ] Open Dev Site in Storyblok
- [ ] See that there are no ESI Tags