### PR TITLE
Fix folder path concatenation in Router.php

### DIFF
--- a/Controller/Router.php
+++ b/Controller/Router.php
@@ -59,7 +59,7 @@ class Router implements RouterInterface
             $folderPath = $this->config->getFolderPath();
 
             if ($folderPath) {
-                $identifier = $folderPath . $identifier;
+                $identifier = trim($folderPath, '/') . '/' . ltrim($identifier, '/');
             }
         }
 


### PR DESCRIPTION
# Description

Normalise the `$folderPath` to only include a `/` where it should be

Fixes #25 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update